### PR TITLE
added assertion of response body string

### DIFF
--- a/playtest-gauge-rest/src/main/kotlin/com/uzabase/playtest/gauge/rest/http/HttpStep.kt
+++ b/playtest-gauge-rest/src/main/kotlin/com/uzabase/playtest/gauge/rest/http/HttpStep.kt
@@ -111,6 +111,11 @@ class HttpStep {
         Assertions.assertTrue(headers.getValue(key) == value)
     }
 
+    @Step("レスポンスボディが文字列<stringValue>である")
+    fun assertResponseBodyStringEquals(stringValue: String) {
+        Assertions.assertEquals(DataStore.loadResponseBodyFromScenario().string, stringValue)
+    }
+
     fun toHeaderMap(header: String): Map<String, String> {
         return header
                 .split("r\n")

--- a/playtest-gauge-rest/src/test/kotlin/com/uzabase/playtest/gauge/rest/http/HttpStepTest.kt
+++ b/playtest-gauge-rest/src/test/kotlin/com/uzabase/playtest/gauge/rest/http/HttpStepTest.kt
@@ -1,5 +1,9 @@
 package com.uzabase.playtest.gauge.rest.http
 
+import com.uzabase.playtest.gauge.rest.DataStore
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -19,5 +23,17 @@ internal class HttpStepTest {
         )
         val headerString = "content-type: application/json r\n options: 111,222" // gaugeのステップは文字列で受け取ると、最初の\が消える
         httpStep.toHeaderMap(headerString) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun レスポンスボディの文字列が渡された文字列と一致する() {
+        val httpStep = HttpStep()
+        val responseString = "Hello world!"
+        mockkObject(DataStore)
+        every { DataStore.loadResponseBodyFromScenario() } returns ResponseBody(responseString, responseString.toByteArray())
+
+        httpStep.assertResponseBodyStringEquals(responseString)
+
+        verify { DataStore.loadResponseBodyFromScenario()}
     }
 }


### PR DESCRIPTION
# 修正概要

レスポンスがJSON形式でない文字列の場合でも利用できるようなStepの実装を追加しました。

# 背景

現状はレスポンスがJSON形式でない場合のアサーションが見当たらないように見えたので、追加したいと思いました。