### PR TITLE
HttpStep.ktのtoHeaderMapで使っている区切り文字に誤字があり、パースに失敗する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ logs/
 
 # Maven
 target/
+
+# VSCode
+.vscode/

--- a/playtest-gauge-rest/src/main/kotlin/com/uzabase/playtest/gauge/rest/http/HttpStep.kt
+++ b/playtest-gauge-rest/src/main/kotlin/com/uzabase/playtest/gauge/rest/http/HttpStep.kt
@@ -128,7 +128,7 @@ class HttpStep {
 
     fun toHeaderMap(header: String): Map<String, String> {
         return header
-            .split("r\n")
+            .split("\n")
             .associate {
                 it.split(":")
                     .map { v -> v.trim() }


### PR DESCRIPTION
区切り文字が `r\n` になっており、複数ヘッダをうまくパースできない。 `\n` が正しいと思う。