### PR TITLE
MySQL8のドライバーに対応

### DIFF
--- a/playtest-db/src/main/kotlin/com/uzabase/playtest/db/Database.kt
+++ b/playtest-db/src/main/kotlin/com/uzabase/playtest/db/Database.kt
@@ -68,7 +68,7 @@ open class Database(
         if (this.driverClass == "org.postgresql.Driver") {
             connection.config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, PostgresqlDataTypeFactory())
         }
-        if (this.driverClass == "com.mysql.jdbc.Driver") {
+        if (this.driverClass == "com.mysql.jdbc.Driver" || this.driverClass == "com.mysql.cj.jdbc.Driver") {
             connection.config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, MySqlDataTypeFactory())
             connection.config.setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER, MySqlMetadataHandler())
         }

--- a/playtest-db/src/test/kotlin/com/uzabase/playtest/db/DatabaseTest.kt
+++ b/playtest-db/src/test/kotlin/com/uzabase/playtest/db/DatabaseTest.kt
@@ -220,4 +220,24 @@ internal class DatabaseTest {
         verify { config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, any<MySqlDataTypeFactory>()) }
         verify { config.setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER, any<MySqlMetadataHandler>()) }
     }
+
+    @Test
+    fun DriverがMySQL8の場合MySQL用の設定を有効にする() {
+        val mysqlDb = Database(
+            driverClass = "com.mysql.cj.jdbc.Driver",
+            url = "jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            username = "sa",
+            password = "",
+            schema = "test_schema"
+        )
+        val connection = mockk<IDatabaseConnection>()
+        val config = mockk<DatabaseConfig>()
+
+        every { connection.config } returns config
+        every { config.setProperty(any(), any()) } just runs
+        mysqlDb.setConfig(connection)
+
+        verify { config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, any<MySqlDataTypeFactory>()) }
+        verify { config.setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER, any<MySqlMetadataHandler>()) }
+    }
 }


### PR DESCRIPTION
MySQL8からドライバーのクラス名が変更になっているので、MySQLのコンフィギュレーションを入れるための条件に新しいドライバー名も加える必要があります。

参考になるページ: https://support.asteria.com/hc/ja/articles/360019113133-JDBC%E3%83%89%E3%83%A9%E3%82%A4%E3%83%90%E3%83%BC-MySQL-Connector-J-8-0-%E3%82%92%E4%BD%BF%E3%81%86%E3%81%A8%E3%81%8D%E3%81%AE%E6%B3%A8%E6%84%8F%E7%82%B9%E3%81%AF%E3%81%82%E3%82%8A%E3%81%BE%E3%81%99%E3%81%8B-