### PR TITLE
:sparkles:playtest-gauge-db: count.spec 指定した値が存在することをアサートする 

### DIFF
--- a/playtest-gauge-db/specs/assert/count.spec
+++ b/playtest-gauge-db/specs/assert/count.spec
@@ -1,0 +1,11 @@
+# レコード数のアサート
+tags: _setup
+
+## 存在するレコード数をアサートする
+* DB"test_db"の"test"スキーマの"todos"テーブルの、条件"id = 'cc23f9f1-4e6a-4e9a-a17f-3de5e3600691'"なレコード数が"0"である
+* DB"test_db"の"test"スキーマの"todos"テーブルの、条件"id = '404e05a3-a34f-47d0-8997-968d90ba64ca'"なレコード数が"1"である
+* DB"test_db"の"test"スキーマの"todos"テーブルの、条件"priority = 1"なレコード数が"2"である
+
+## 存在するレコード数を複数条件でアサートする
+* DB"test_db"の"test"スキーマの"todos"テーブルの、条件"memo is NULL AND done = false"なレコード数が"0"である
+* DB"test_db"の"test"スキーマの"todos"テーブルの、条件"memo is NULL AND done = true"なレコード数が"1"である

--- a/playtest-gauge-db/src/main/kotlin/com/uzabase/playtest/gauge/db/DatabaseStep.kt
+++ b/playtest-gauge-db/src/main/kotlin/com/uzabase/playtest/gauge/db/DatabaseStep.kt
@@ -213,6 +213,21 @@ class DatabaseStep {
         assertThat(request).hasNumberOfRows(0)
     }
 
+    @Step("DB<dbName>の<schemaName>スキーマの<tableName>テーブルの、条件<where>なレコード数が<count>である")
+    fun assertSelectRecordCount(
+        dbName: String,
+        schemaName: String,
+        tableName: String,
+        where: String,
+        count: Int
+    ) {
+        getSource(dbName, schemaName, tableName).let {
+            Request(it, "select * from $schemaName.$tableName where $where")
+        }.run {
+            assertThat(this).hasNumberOfRows(count)
+        }
+    }
+
     @Step("DB<dbName>の<schemaName>スキーマの<tableName>テーブルのレコード数が<count>である")
     fun assertRecordCount(
         dbName: String,


### PR DESCRIPTION
存在することの確認として、`DB<dbName>の<schemaName>スキーマの<tableName>テーブルの、条件<where>なレコード数が<count>である`を追加しました。

~`DB<dbName>の<schemaName>スキーマの<tableName>テーブルに、<whereColumn>が<whereValue>なレコードが存在する`のステップも追加したほうがよいかな~
個人的にはテストの際はDBに存在するレコード数は知っているはずだし、レコードが存在するか確認するための方法を2種類用意する必要はなくてもいいかなと思いました。

close #10 